### PR TITLE
Add 'sites' dependency to initial migration

### DIFF
--- a/account/migrations/0001_initial.py
+++ b/account/migrations/0001_initial.py
@@ -32,6 +32,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('sites', '0001_initial')
     ]
 
     operations = [


### PR DESCRIPTION
_Related: https://github.com/GeoNode/geonode/issues/2488_

While working on upgrading [Exchange to use GeoNode 2.4](https://github.com/boundlessgeo/exchange/pull/13), I ran into an issue with migration dependencies: running `migrate` on our upgraded project resulted in a "relation does not exist" error, indicating `account`. However doing `migrate account` shows a dependency on `sites`, and following that dependency chain (involving `sites`, `auth`, `contenttypes`, and back to `account`) results in additional errors.

I did see [this post on the ML](https://lists.osgeo.org/pipermail/geonode-devel/2016-February/000780.html), but even following that order of operations I still run into nonexistent relation errors that ultimately trace back to `account`.

Adding `sites` as a dependency within the `account` migration here solves this & allows the DB to be initialized without error. If this is incorrect, or there is a better solution, please let me know!