### PR TITLE
Fix default value for EmailConfirmation.created.

### DIFF
--- a/account/migrations/0002_fix_emailconfirmation_created.py
+++ b/account/migrations/0002_fix_emailconfirmation_created.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('account', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='emailconfirmation',
+            name='created',
+            field=models.DateTimeField(default=django.utils.timezone.now),
+        ),
+    ]

--- a/account/models.py
+++ b/account/models.py
@@ -292,7 +292,7 @@ class EmailAddress(models.Model):
 class EmailConfirmation(models.Model):
 
     email_address = models.ForeignKey(EmailAddress)
-    created = models.DateTimeField(default=timezone.now())
+    created = models.DateTimeField(default=timezone.now)
     sent = models.DateTimeField(null=True)
     key = models.CharField(max_length=64, unique=True)
 


### PR DESCRIPTION
Fixing a bad default definition.
This fix is already present in the [original repo](https://github.com/pinax/django-user-accounts/blob/master/account/models.py#L304).
There's some info about this fix on [StackOverlflow](http://stackoverflow.com/questions/29733203/django-default-datetime-now-in-models-always-saves-same-datetime-after-uwsgi-r/29733276#29733276).

The provided commit fixes both the Model and the DB (by using a migration).