### PR TITLE
make default value a callable, not the actual time

### DIFF
--- a/account/migrations/0001_initial.py
+++ b/account/migrations/0001_initial.py
@@ -427,7 +427,7 @@ class Migration(migrations.Migration):
             name='EmailConfirmation',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('created', models.DateTimeField(default=datetime.datetime(2016, 5, 1, 8, 49, 9, 848764))),
+                ('created', models.DateTimeField(default=django.utils.timezone.now)),
                 ('sent', models.DateTimeField(null=True)),
                 ('key', models.CharField(unique=True, max_length=64)),
                 ('email_address', models.ForeignKey(to='account.EmailAddress')),

--- a/account/models.py
+++ b/account/models.py
@@ -96,7 +96,7 @@ def user_post_save(sender, **kwargs):
     After User.save is called we check to see if it was a created user. If so,
     we check if the User object wants account creation. If all passes we
     create an Account object.
-    
+
     We only run on user creation to avoid having to check for existence on
     each call to User.save.
     """
@@ -292,7 +292,7 @@ class EmailAddress(models.Model):
 class EmailConfirmation(models.Model):
 
     email_address = models.ForeignKey(EmailAddress)
-    created = models.DateTimeField(default=timezone.now())
+    created = models.DateTimeField(default=timezone.now)
     sent = models.DateTimeField(null=True)
     key = models.CharField(max_length=64, unique=True)
 


### PR DESCRIPTION
Ref: https://github.com/GeoNode/geonode/issues/2501

Uses the callable (instead of the actual computed time) as the default field value. This way the field default is the current time at time of object creation, vs server start time. This also stops a new migration from being created for `accounts` every time `python manage.py makemigrations` is run.